### PR TITLE
feat: Banner 컴포넌트 구현

### DIFF
--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -1,0 +1,17 @@
+import type { BannerProps } from './Banner.types';
+
+// TODO: Tab 컴포넌트 추가 필요
+const Banner = ({ title, subtitle }: BannerProps) => {
+  return (
+    <section className="flex w-full items-center justify-between">
+      <div className="flex pt-11 flex-col gap-3">
+        <h1 className="text-gray-900 text-5xl">{title}</h1>
+        <div className="pl-0.5">
+          <p className="text-gray-500 text-2xl font-normal">{subtitle}</p>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Banner;

--- a/src/components/Banner/Banner.types.tsx
+++ b/src/components/Banner/Banner.types.tsx
@@ -1,0 +1,4 @@
+export interface BannerProps {
+  title: string;
+  subtitle?: string;
+}

--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -5,7 +5,7 @@ import { Logo } from '../Logo/Logo';
 const NavigationBar = () => {
   return (
     <header className="bg-white w-full border-b border-gray-200 sticky top-0 z-50">
-      <div className="max-w-7xl mx-auto px-4">
+      <div className="max-w-7xl mx-auto">
         <div className="flex items-center justify-between h-16">
           <Logo.Basic />
           <div className="flex items-center gap-3">

--- a/src/global.css
+++ b/src/global.css
@@ -22,7 +22,8 @@
 }
 
 html {
-  font-size: 1rem;
+  padding: 0;
+  margin: 0;
 }
 
 body {


### PR DESCRIPTION
## ✅ 체크리스트

- [x] Banner 컴포넌트 구현

## 📝 작업 상세 내용

> 임시 Banner 컴포넌트 구현이 완료되었습니다. 아래와 같이 사용 가능합니다. 

```tsx
return <Banner title="배너 타이틀" subtitle="배너 서브 타이틀입니다. 세부 내용이 표시됩니다." />;
```

## 🔎 후속 작업 (선택 사항)

- Tab 컴포넌트 추가가 필요합니다. (목록 정렬 용도)
- 디자인이 변경될 수 있습니다.

## 📸 스크린샷 (선택 사항)

<img width="1356" height="161" alt="스크린샷 2025-12-28 오후 11 55 42" src="https://github.com/user-attachments/assets/365c8fa4-868c-4cca-b55c-4c97db3885e3" />

## ✅ 셀프 체크리스트

- [x] 브랜치 확인하기
- [x] 불필요한 코드가 들어가지 않았는지 재확인하기
- [x] issue 닫기
- [x] reiewers, assignees, Lables 등록 확인하기

**이슈 번호**: #11 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 제목과 부제목을 표시하는 새로운 배너 컴포넌트가 추가되었습니다.

* **스타일**
  * 내비게이션 바의 패딩을 조정하여 더 나은 레이아웃을 제공합니다.
  * 전역 CSS 규칙을 개선하여 기본 스타일을 최적화했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->