### PR TITLE
feat: Badge 컴포넌트 구현

### DIFF
--- a/src/components/Badge/Badge.styles.ts
+++ b/src/components/Badge/Badge.styles.ts
@@ -1,0 +1,11 @@
+export const variantStyleMap = {
+  category: 'bg-purple-50 text-purple-700',
+  platform: 'bg-indigo-50 text-indigo-700',
+  source: 'bg-gray-100 text-gray-700',
+};
+
+export const variantIconMap = {
+  category: 'bookmark',
+  platform: 'circuit',
+  source: 'link',
+} as const;

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,0 +1,16 @@
+import type { BadgeProps } from './Badge.types';
+
+import { Icon } from '../Icon/Icon';
+import { variantIconMap, variantStyleMap } from './Badge.styles';
+
+const Badge = ({ variant, children }: BadgeProps) => {
+  return (
+    <div
+      className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg ${variantStyleMap[variant]}`}>
+      <Icon name={variantIconMap[variant]} fill="#fff" />
+      <span>{children}</span>
+    </div>
+  );
+};
+
+export default Badge;

--- a/src/components/Badge/Badge.types.ts
+++ b/src/components/Badge/Badge.types.ts
@@ -1,0 +1,11 @@
+import type { variantStyleMap } from './Badge.styles';
+
+type BadgeStyleVariant = {
+  variant: keyof typeof variantStyleMap;
+};
+
+interface BadgeBaseProps {
+  children: React.ReactNode;
+}
+
+export type BadgeProps = BadgeBaseProps & BadgeStyleVariant;


### PR DESCRIPTION
## ✅ 체크리스트

- [x] Badge 컴포넌트 구현

## 📝 작업 상세 내용

> Badge 컴포넌트 구현이 완료됐습니다. 아래와 같이 사용 가능합니다. 

```tsx
<Badge variant="category">글쓰기</Badge>
<Badge variant="platform">ChatGPT</Badge>
<Badge variant="source">출처</Badge>
```

## 🔎 후속 작업 (선택 사항)

- `variant=source`: 삭제 가능성 존재

## 📸 스크린샷 (선택 사항)

<img width="396" height="115" alt="스크린샷 2025-12-29 오전 12 23 55" src="https://github.com/user-attachments/assets/75491c7e-c241-461b-8754-5d243e1d7907" />

## ✅ 셀프 체크리스트

- [x] 브랜치 확인하기
- [x] 불필요한 코드가 들어가지 않았는지 재확인하기
- [x] issue 닫기
- [x] reiewers, assignees, Lables 등록 확인하기

**이슈 번호**: #12 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Badge 컴포넌트 추가: 카테고리, 플랫폼, 소스 변형을 지원하는 뱃지 UI 요소 도입
  * 각 변형에 따른 스타일 및 아이콘 자동 적용

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->