### PR TITLE
feat: Card 컴포넌트 구현

### DIFF
--- a/src/components/Badge/Badge.styles.ts
+++ b/src/components/Badge/Badge.styles.ts
@@ -9,3 +9,8 @@ export const variantIconMap = {
   platform: 'circuit',
   source: 'link',
 } as const;
+
+export const badgeSizeMap = {
+  sm: 'gap-1 px-2.5 py-1 rounded-md text-sm',
+  md: 'gap-1.5 px-3 py-1.5 rounded-lg',
+};

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,12 +1,11 @@
 import type { BadgeProps } from './Badge.types';
 
 import { Icon } from '../Icon/Icon';
-import { variantIconMap, variantStyleMap } from './Badge.styles';
+import { badgeSizeMap, variantIconMap, variantStyleMap } from './Badge.styles';
 
-const Badge = ({ variant, children }: BadgeProps) => {
+const Badge = ({ size = 'md', variant, children }: BadgeProps) => {
   return (
-    <div
-      className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg ${variantStyleMap[variant]}`}>
+    <div className={`inline-flex items-center ${badgeSizeMap[size]} ${variantStyleMap[variant]}`}>
       <Icon name={variantIconMap[variant]} fill="#fff" />
       <span>{children}</span>
     </div>

--- a/src/components/Badge/Badge.types.ts
+++ b/src/components/Badge/Badge.types.ts
@@ -1,8 +1,11 @@
 import type { ReactNode } from 'react';
 import type { variantStyleMap } from './Badge.styles';
 
+export type BadgeVariants = keyof typeof variantStyleMap;
+
 type BadgeStyleVariant = {
-  variant: keyof typeof variantStyleMap;
+  size?: 'sm' | 'md';
+  variant: BadgeVariants;
 };
 
 interface BadgeBaseProps {

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -2,12 +2,14 @@ import { Label } from '../../Label/Label';
 import Badge from '../Badge/Badge';
 import type { CardProps } from './Card.types';
 
-const Card = ({ badges, view, date, writer, header, children }: CardProps) => {
+const Card = ({ id, badges, view, date, writer, header, children }: CardProps) => {
   return (
-    <article className="bg-white rounded-xl border border-gray-200 p-6 hover:border-purple-300 hover:shadow-lg transition-all text-left group">
+    <article
+      key={id}
+      className="bg-white rounded-xl border border-gray-200 p-6 hover:border-purple-300 hover:shadow-lg transition-all text-left group">
       <header className="flex items-center gap-2 mb-3 flex-wrap">
         {badges.map((badge) => (
-          <Badge size="sm" variant={badge.variant}>
+          <Badge key={badge.id} size="sm" variant={badge.variant}>
             {badge.name}
           </Badge>
         ))}

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,0 +1,34 @@
+import { Label } from '../../Label/Label';
+import Badge from '../Badge/Badge';
+import type { CardProps } from './Card.types';
+
+const Card = ({ badges, view, date, writer, header, children }: CardProps) => {
+  return (
+    <article className="bg-white rounded-xl border border-gray-200 p-6 hover:border-purple-300 hover:shadow-lg transition-all text-left group">
+      <header className="flex items-center gap-2 mb-3 flex-wrap">
+        {badges.map((badge) => (
+          <Badge size="sm" variant={badge.variant}>
+            {badge.name}
+          </Badge>
+        ))}
+      </header>
+      <main>
+        <h3 className="text-gray-900 mb-2 group-hover:text-purple-600 transition-colors line-clamp-2">
+          {header}
+        </h3>
+        <p className="text-gray-600 text-sm mb-4 line-clamp-3">{children}</p>
+      </main>
+      <footer className="flex items-center justify-between pt-4 border-t border-gray-100">
+        <div className="flex items-center gap-4">
+          <Label.Text icon="view">{view}</Label.Text>
+          <Label.Text icon="calendar">{date}</Label.Text>
+        </div>
+        <Label.Text>{writer}</Label.Text>
+      </footer>
+    </article>
+  );
+};
+
+export default Card;
+
+// 카드 세부 내용입니다. 작성자가 작성한 프롬프트의 미리보기가 최대 3줄까지 표시됩니다. 세 줄 초과 시 말줄임표로 표시됩니다. 카드 세부 내용입니다. 작성자가 작성한 프롬프트의 미리보기가 최대 3줄까지 표시됩니다. 세 줄 초과 시 말줄임표로 표시됩니다.

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -30,5 +30,3 @@ const Card = ({ badges, view, date, writer, header, children }: CardProps) => {
 };
 
 export default Card;
-
-// 카드 세부 내용입니다. 작성자가 작성한 프롬프트의 미리보기가 최대 3줄까지 표시됩니다. 세 줄 초과 시 말줄임표로 표시됩니다. 카드 세부 내용입니다. 작성자가 작성한 프롬프트의 미리보기가 최대 3줄까지 표시됩니다. 세 줄 초과 시 말줄임표로 표시됩니다.

--- a/src/components/Card/Card.types.ts
+++ b/src/components/Card/Card.types.ts
@@ -2,11 +2,13 @@ import type { ReactNode } from 'react';
 import type { BadgeVariants } from '../Badge/Badge.types';
 
 export interface CardBadges {
+  id: string;
   name: string;
   variant: BadgeVariants;
 }
 
 interface CardBaseProps {
+  id: number;
   badges: CardBadges[];
   header: string;
   children: ReactNode;

--- a/src/components/Card/Card.types.ts
+++ b/src/components/Card/Card.types.ts
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react';
+import type { BadgeVariants } from '../Badge/Badge.types';
+
+export interface CardBadges {
+  name: string;
+  variant: BadgeVariants;
+}
+
+interface CardBaseProps {
+  badges: CardBadges[];
+  header: string;
+  children: ReactNode;
+  view: string;
+  date: string;
+  writer: string;
+}
+
+export type CardProps = CardBaseProps;


### PR DESCRIPTION
## ✅ 체크리스트

- [x] Badge 컴포넌트 sizeMap 객체 추가 (sm, md)
- [x] Card 컴포넌트 구현

## 📝 작업 상세 내용

> Card 컴포넌트 구현이 완료되었습니다. 아래와 같이 사용 가능합니다.

```tsx
<Card header="카드 제목입니다." badges={badges} view="1.8K" date="2025.12.29" writer="익명">
  카드 세부 내용입니다. 작성자가 작성한 프롬프트의 미리보기가 최대 3줄까지 표시됩니다. 세 줄
  초과 시 말줄임표로 표시됩니다. 카드 세부 내용입니다. 작성자가 작성한 프롬프트의 미리보기가
  최대 3줄까지 표시됩니다. 세 줄 초과 시 말줄임표로 표시됩니다.
</Card>
```

## 🔎 후속 작업 (선택 사항)

> prop 구조가 변경될 수 있습니다. Card 컴포넌트를 도메인 구조에 강하게 묶이도록 설계할 것인지, 재사용 가능성을 두고 UI 컴포넌트로 느슨하게 확장성을 열어 둘지 고민 중입니다.

## 📸 스크린샷 (선택 사항)

<img width="1371" height="286" alt="스크린샷 2025-12-29 오후 3 06 42" src="https://github.com/user-attachments/assets/c044a5bf-6e57-4305-ade8-884e92c9b380" />

hover 시:

<img width="453" height="271" alt="스크린샷 2025-12-29 오후 3 11 12" src="https://github.com/user-attachments/assets/e2702fe4-e8a5-4956-9f20-0ef8e1101c80" />

## ✅ 셀프 체크리스트

- [x] 브랜치 확인하기
- [x] 불필요한 코드가 들어가지 않았는지 재확인하기
- [x] issue 닫기
- [x] reiewers, assignees, Lables 등록 확인하기

**이슈 번호**: #13 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Badge 컴포넌트에 크기 옵션(sm, md) 추가 — 다양한 크기의 뱃지 표시 가능.
  * Card 컴포넌트 추가 — 뱃지 목록, 헤더, 본문(라인클램프 적용), 푸터(조회수·날짜·작성자)로 구성된 카드형 콘텐츠 표시 및 반응형/호버 애니메이션 지원.
  * 타입/속성 확장으로 컴포넌트 간 일관된 속성 전달 개선.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->