### PR TITLE
feat: 프롬프트 등록 페이지 UI 구현

### DIFF
--- a/src/components/Button/Button.styles.ts
+++ b/src/components/Button/Button.styles.ts
@@ -1,5 +1,6 @@
 export const buttonVariants = {
   solid: `bg-gray-900 hover:bg-gray-800 transition-colors text-white px-4`,
   primary: `bg-primary-gradient hover:from-purple-700 hover:to-indigo-700 text-white px-4`,
+  secondary: 'bg-gray-100 text-gray-700 hover:bg-gray-200 transition-colors',
   empty: 'text-gray-600 hover:text-gray-900 transition-colors',
 };

--- a/src/components/Button/Button.styles.ts
+++ b/src/components/Button/Button.styles.ts
@@ -1,6 +1,6 @@
 export const buttonVariants = {
   solid: `bg-gray-900 hover:bg-gray-800 transition-colors text-white px-4`,
   primary: `bg-primary-gradient hover:from-purple-700 hover:to-indigo-700 text-white px-4`,
-  secondary: 'bg-gray-100 text-gray-700 hover:bg-gray-200 transition-colors',
+  secondary: 'bg-gray-100 text-gray-700 hover:bg-gray-200 transition-colors px-4',
   empty: 'text-gray-600 hover:text-gray-900 transition-colors',
 };

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -8,7 +8,7 @@ type ButtonStyleVariant = {
 
 interface ButtonBaseProps extends Omit<ComponentPropsWithRef<'button'>, 'children'> {
   icon?: IconName;
-  children: ReactNode;
+  children?: ReactNode;
 }
 
 export type ButtonProps = ButtonBaseProps & ButtonStyleVariant;

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -3,7 +3,7 @@ import type { IconName, IconSize } from '../Icon/Icon.types';
 
 type ButtonStyleVariant = {
   iconSize?: IconSize;
-  variant?: 'solid' | 'primary' | 'empty';
+  variant?: 'solid' | 'primary' | 'secondary' | 'empty';
 };
 
 interface ButtonBaseProps extends Omit<ComponentPropsWithRef<'button'>, 'children'> {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,0 +1,20 @@
+export const CATEGORY_OPTIONS = [
+  { label: '카테고리 선택', value: 'default' },
+  { label: '글쓰기', value: 'writing' },
+  { label: '이미지 생성', value: 'image' },
+  { label: '개발', value: 'dev' },
+  { label: '마케팅', value: 'marketing' },
+  { label: '교육', value: 'education' },
+  { label: '번역', value: 'translation' },
+  { label: '데이터 분석', value: 'data' },
+  { label: '기타', value: 'etc' },
+];
+
+export const PLATFORM_OPTIONS = [
+  { label: '플랫폼 선택', value: 'default' },
+  { label: 'ChatGPT', value: 'chatgpt' },
+  { label: 'Claude', value: 'claude' },
+  { label: 'Gemini', value: 'gemini' },
+  { label: 'Midjourney', value: 'midjourney' },
+  { label: '기타', value: 'etc' },
+];

--- a/src/global.css
+++ b/src/global.css
@@ -30,7 +30,7 @@
   --color-brand-purple-300: oklch(0.827 0.119 306.383);
   --color-brand-purple-400: oklch(0.714 0.203 305.504);
   --color-brand-purple-500: oklch(0.627 0.265 303.9);
-  --color-brand-purple-600: oklch(0.511 0.262 276.966);
+  --color-brand-purple-600: oklch(0.558 0.288 302.321);
   --color-brand-purple-700: oklch(0.496 0.265 301.924);
 
   --color-brand-indigo-50: oklch(0.962 0.018 272.314);

--- a/src/pages/CreatePrompt/CreatePromptPage.tsx
+++ b/src/pages/CreatePrompt/CreatePromptPage.tsx
@@ -1,0 +1,20 @@
+import Button from '../../components/Button/Button';
+import CreatePromptForm from './_components/CreatePromptForm';
+
+const CreatePromptPage = () => {
+  return (
+    <div className="w-3xl">
+      <section className="w-full max-w-2xl bg-white rounded-xl border border-gray-200 overflow-hidden shadow-sm">
+        <header className="flex items-center justify-between p-6 border-b border-gray-200">
+          <h2 className="text-gray-900 text-lg">프롬프트 등록</h2>
+          <Button icon="close" variant="empty" aria-label="닫기" />
+        </header>
+        <div className="p-6">
+          <CreatePromptForm />
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default CreatePromptPage;

--- a/src/pages/CreatePrompt/_components/CreatePromptForm.tsx
+++ b/src/pages/CreatePrompt/_components/CreatePromptForm.tsx
@@ -1,0 +1,52 @@
+import Button from '../../../components/Button/Button';
+import FormField from '../../../components/Form/FormField';
+import { Input } from '../../../components/Input/Input';
+import { CATEGORY_OPTIONS, PLATFORM_OPTIONS } from '../../../config/constants';
+
+const CreatePromptForm = () => {
+  return (
+    <form className="space-y-6">
+      <FormField htmlFor="title" label="제목" required>
+        <Input.InputField id="title" placeholder="프롬프트 제목을 입력해 주세요" />
+      </FormField>
+      <FormField htmlFor="category" label="카테고리" required>
+        <Input.SelectField id="category" options={CATEGORY_OPTIONS} />
+      </FormField>
+      <FormField htmlFor="platform" label="플랫폼" required>
+        <Input.SelectField id="platform" options={PLATFORM_OPTIONS} />
+      </FormField>
+      <FormField htmlFor="body" label="프롬프트 내용" required>
+        <Input.TextField id="body" placeholder="프롬프트 내용을 입력해 주세요" />
+      </FormField>
+      <FormField htmlFor="source" label="출처">
+        <Input.InputField
+          id="source"
+          placeholder="링크를 입력해 주세요. (본인이라면 작성자로 표기)"
+        />
+      </FormField>
+      <FormField htmlFor="tips" label="팁">
+        <Input.InputField id="tips" placeholder="프롬프트 사용 팁을 입력해 주세요" />
+      </FormField>
+      <div className="flex items-center gap-3">
+        <input
+          type="checkbox"
+          id="anonymous"
+          className="w-5 h-5 text-purple-600 border-gray-300 rounded focus:ring-2 focus:ring-purple-500"
+        />
+        <label htmlFor="anonymous" className="text-gray-700 cursor-pointer">
+          익명으로 등록
+        </label>
+      </div>
+      <div className="flex items-center gap-3 pt-4">
+        <Button className="w-full" variant="secondary" type="button">
+          취소
+        </Button>
+        <Button className="w-full" variant="primary" type="submit">
+          등록하기
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export default CreatePromptForm;

--- a/src/pages/CreatePrompt/_components/CreatePromptForm.tsx
+++ b/src/pages/CreatePrompt/_components/CreatePromptForm.tsx
@@ -31,6 +31,7 @@ const CreatePromptForm = () => {
         <input
           type="checkbox"
           id="anonymous"
+          name="anonymous"
           className="w-5 h-5 text-purple-600 border-gray-300 rounded focus:ring-2 focus:ring-purple-500"
         />
         <label htmlFor="anonymous" className="text-gray-700 cursor-pointer">

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -3,6 +3,7 @@ import PromptListPage from './pages/PromptList/PromptListPage';
 import Layout from './components/Layout/Layout';
 import PromptDetailPage from './pages/PromptDetail/PromptDetailPage';
 import KakaoCallbackPage from './pages/Auth/KakaoCallbackPage';
+import CreatePromptPage from './pages/CreatePrompt/CreatePromptPage';
 
 const Router = () => {
   return (
@@ -11,6 +12,7 @@ const Router = () => {
         <Route path="/" element={<PromptListPage />} />
         <Route path="/:promptId" element={<PromptDetailPage />} />
         <Route path="/auth/kakao/callback" element={<KakaoCallbackPage />} />
+        <Route path="/write" element={<CreatePromptPage />}/>
       </Route>
     </Routes>
   );


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 프롬프트 등록 페이지 UI 구현
  - [x] 프롬프트 등록 form 컴포넌트 UI 구현
  - [x] 버튼 컴포넌트 variant secondary 타입 추가

## 📝 작업 상세 내용

> 프롬프트 등록 페이지 UI 구현이 완료되었습니다. 추후 디자인이 변경될 수 있습니다.
  
![createPromptPage](https://github.com/user-attachments/assets/3911b025-93d1-45c9-8fc2-1afa7bf9463e)

## 🔎 후속 작업 (선택 사항)

- icon만 사용하는 경우를 고려해 버튼 컴포넌트의 `children` prop을 옵셔널로 변경해 둔 상태입니다. 별도의 컴포넌트로 분리해야 할지 이대로 가는 게 맞을지 고민 중입니다.
- variant 타입에 따른 버튼 컴포넌트의 역할이 명확한지 검토해 봐야 합니다.
- 프롬프트 등록 form에 액션을 위한 useForm 훅이 추가되어야 합니다.

## ✅ 셀프 체크리스트

- [x] 브랜치 확인하기
- [x] 불필요한 코드가 들어가지 않았는지 재확인하기
- [x] issue 닫기
- [x] reiewers, assignees, Lables 등록 확인하기

**이슈 번호**: #34 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 프롬프트 등록 페이지 추가 — 제목, 카테고리, 플랫폼 선택, 본문, 출처, 팁, 익명 등록 등 입력 후 등록 가능
  * 카테고리 및 플랫폼 선택 옵션 추가
  * 글 작성 페이지로 이동 가능한 경로 추가

* **스타일**
  * 보조(secondary) 버튼 스타일 추가
  * 브랜드 보라색 색상 업데이트

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->