### PR TITLE
feat: 프롬프트 필터링 기능 구현

### DIFF
--- a/src/apis/prompts/prompts.ts
+++ b/src/apis/prompts/prompts.ts
@@ -14,10 +14,15 @@ export const getPromptList = async ({
   sort = 'latest',
   page = 1,
   size = 20,
+  categoryIds,
+  platformIds,
 }: GetPromptListParams = {}): Promise<PromptListResponse> => {
-  const { data } = await API.get('/api/prompts', {
-    params: { sort, page, size },
-  });
+  const params: GetPromptListParams = { sort, page, size };
+
+  if (categoryIds) params.categoryIds = categoryIds;
+  if (platformIds) params.platformIds = platformIds;
+
+  const { data } = await API.get('/api/prompts', { params });
 
   return data;
 };

--- a/src/apis/prompts/prompts.types.ts
+++ b/src/apis/prompts/prompts.types.ts
@@ -62,6 +62,8 @@ export interface GetPromptListParams {
   sort?: SortType;
   page?: number;
   size?: number;
+  categoryIds?: number[];
+  platformIds?: number[];
 }
 
 // prompt detail

--- a/src/components/Input/Input.types.ts
+++ b/src/components/Input/Input.types.ts
@@ -10,7 +10,7 @@ export type TextFieldProps = ComponentPropsWithRef<'textarea'> & {
 };
 
 interface SelectOption {
-  value: string;
+  value: string | number;
   label: string;
 }
 
@@ -18,6 +18,5 @@ export interface SelectFieldProps extends ComponentPropsWithRef<typeof SelectPri
   options: SelectOption[];
   placeholder?: string;
   className?: string;
-  defaultValue?: string;
   ref?: React.Ref<HTMLButtonElement>;
 }

--- a/src/hooks/common/useMetaOptions.ts
+++ b/src/hooks/common/useMetaOptions.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { getCategories, getPlatforms } from '../../apis/common/meta';
 
 interface SelectOption {
+  slug: string;
   value: number;
   label: string;
 }
@@ -12,7 +13,8 @@ export const useMetaOptions = () => {
     queryFn: getCategories,
     staleTime: Infinity,
     gcTime: Infinity,
-    select: (data): SelectOption[] => data.map((item) => ({ label: item.name, value: item.id })),
+    select: (data): SelectOption[] =>
+      data.map((item) => ({ label: item.name, value: item.id, slug: item.slug })),
   });
 
   const platformQuery = useQuery({
@@ -20,7 +22,8 @@ export const useMetaOptions = () => {
     queryFn: getPlatforms,
     staleTime: Infinity,
     gcTime: Infinity,
-    select: (data): SelectOption[] => data.map((item) => ({ label: item.name, value: item.id })),
+    select: (data): SelectOption[] =>
+      data.map((item) => ({ label: item.name, value: item.id, slug: item.slug })),
   });
 
   return {

--- a/src/pages/PromptList/PromptListPage.tsx
+++ b/src/pages/PromptList/PromptListPage.tsx
@@ -10,7 +10,7 @@ import { TextLabel } from '../../components/Label/Label';
 import { SORT_OPTIONS } from '../../config/constants';
 import { usePromptList } from '../../hooks/prompts/usePromptList';
 import useMyLikedPromptIds from '../../hooks/likes/useMyLikedPromptIds';
-
+import { useMetaOptions } from '../../hooks/common/useMetaOptions';
 import type { SortType } from '../../apis/prompts/prompts.types';
 
 const PromptListPage = () => {
@@ -19,19 +19,45 @@ const PromptListPage = () => {
   const page = Number(searchParams.get('page')) || 1;
   const sortOrder = (searchParams.get('sort') as SortType) || 'latest';
 
+  const { likedIds } = useMyLikedPromptIds();
+  const { categoryOptions, platformOptions } = useMetaOptions();
+
+  const categoryParam = searchParams.get('category');
+  const platformParam = searchParams.get('platform');
+
+  const selectedCategory = categoryOptions.find((option) => option.slug === categoryParam);
+  const selectedPlatform = platformOptions.find((option) => option.slug === platformParam);
+
+  const categoryIdParam = selectedCategory ? Number(selectedCategory.value) : undefined;
+  const platformIdParam = selectedPlatform ? Number(selectedPlatform.value) : undefined;
+
   const {
     prompts: publicPrompts,
     meta,
     loading,
     error,
-  } = usePromptList({ page, size: 21, sort: sortOrder });
+  } = usePromptList({
+    page,
+    size: 21,
+    sort: sortOrder,
+    categoryIds: categoryIdParam ? [categoryIdParam] : undefined,
+    platformIds: platformIdParam ? [platformIdParam] : undefined,
+  });
 
-  const { likedIds } = useMyLikedPromptIds();
+  const formattedCategoryOptions = [
+    { value: '-1', label: '전체 카테고리' },
+    ...categoryOptions.map((opt) => ({ label: opt.label, value: opt.slug })),
+  ];
+
+  const formattedPlatformOptions = [
+    { value: '-1', label: '전체 플랫폼' },
+    ...platformOptions.map((opt) => ({ label: opt.label, value: opt.slug })),
+  ];
 
   const mergedPrompts = useMemo(() => {
     if (!publicPrompts) return [];
 
-    const likedIdSet = new Set(likedIds);
+    const likedIdSet = new Set(likedIds || []);
 
     return publicPrompts.map((prompt) => ({
       ...prompt,
@@ -41,19 +67,31 @@ const PromptListPage = () => {
   }, [publicPrompts, likedIds]);
 
   const handleSortChange = (newSort: string) => {
-    setSearchParams({
-      sort: newSort,
-      page: '1',
-    });
+    const newParams = new URLSearchParams(searchParams);
+
+    newParams.set('sort', newSort);
+    newParams.set('page', '1');
+
+    setSearchParams(newParams);
   };
 
   const handlePageChange = (newPage: number) => {
-    setSearchParams({
-      sort: sortOrder,
-      page: String(newPage),
-    });
+    const newParams = new URLSearchParams(searchParams);
+
+    newParams.set('page', String(newPage));
+    setSearchParams(newParams);
 
     window.scrollTo(0, 0);
+  };
+
+  const handleFilterChange = (key: string, value: string) => {
+    const newParams = new URLSearchParams(searchParams);
+
+    if (value === '-1' || !value) newParams.delete(key);
+    else newParams.set(key, value);
+
+    newParams.set('page', '1');
+    setSearchParams(newParams);
   };
 
   if (loading) {
@@ -76,21 +114,42 @@ const PromptListPage = () => {
     <div className="space-y-6 flex flex-col flex-1">
       <Banner title="전체 프롬프트" subtitle="다양한 AI 프롬프트를 공유하고 발견하세요" />
       <div className="flex justify-between gap-3 items-center">
-        <TextLabel className="flex pt-4">
-          <p className="pl-1 text-brand-purple">{meta.totalElements}</p>개의 프롬프트
-        </TextLabel>
-        <Input.SelectField
-          defaultValue={SORT_OPTIONS[0].value}
-          value={sortOrder}
-          options={SORT_OPTIONS}
-          onValueChange={handleSortChange}
-        />
+        <div className="flex items-center gap-3">
+          <Input.SelectField
+            placeholder="카테고리 선택"
+            value={categoryParam || '-1'}
+            options={formattedCategoryOptions}
+            onValueChange={(value) => handleFilterChange('category', value)}
+          />
+          <Input.SelectField
+            placeholder="플랫폼 선택"
+            value={platformParam || '-1'}
+            options={formattedPlatformOptions}
+            onValueChange={(value) => handleFilterChange('platform', value)}
+          />
+        </div>
+        <div className="flex gap-3 items-center">
+          <Input.SelectField
+            value={sortOrder}
+            options={SORT_OPTIONS}
+            onValueChange={handleSortChange}
+          />
+          <TextLabel className="flex">
+            <p className="pl-1 text-brand-purple">{meta.totalElements}</p>개의 프롬프트
+          </TextLabel>
+        </div>
       </div>
-      <div className="w-full grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-        {mergedPrompts.map((prompt) => (
-          <PromptCard key={prompt.id} prompt={prompt} router={`/${prompt.id}`} />
-        ))}
-      </div>
+
+      {mergedPrompts.length === 0 ? (
+        <div className="flex justify-center py-20 text-gray-500">해당하는 프롬프트가 없습니다.</div>
+      ) : (
+        <div className="w-full grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {mergedPrompts.map((prompt) => (
+            <PromptCard key={prompt.id} prompt={prompt} router={`/prompts/${prompt.id}`} />
+          ))}
+        </div>
+      )}
+
       <Pagination
         currentPage={meta.page}
         totalSize={meta.totalPages}


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 카테고리 필터링 구현
- [x] 플랫폼 필터링 구현

## 📝 작업 상세 내용

> 카테고리/플랫폼 필터링 구현이 완료되었습니다. 필터링 시, URL 파라미터에 id를 노출할지 slug를 노출할지 고민했을 때 URL 가독성 및 SEO 측면에서 slug로 표시하는 게 좋다 생각되어 `category=write&platform=chatgpt`와 같이 노출되도록 구현했습니다. 

![filtering](https://github.com/user-attachments/assets/773a11af-3835-4b97-8cea-32af37a081c0)

## ✅ 셀프 체크리스트

- [x] 브랜치 확인하기
- [x] 불필요한 코드가 들어가지 않았는지 재확인하기
- [x] issue 닫기
- [x] reiewers, assignees, Lables 등록 확인하기

**이슈 번호**: #51 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 카테고리 및 플랫폼으로 프롬프트를 필터링할 수 있습니다.
  * 좋아하는 프롬프트에 표시 기능이 추가되었습니다.
  * 필터 및 정렬 선택 사항이 URL에 저장되어 공유 및 북마크가 용이합니다.

* **Improvements**
  * 필터 UI가 상단으로 이동하여 접근성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->